### PR TITLE
Preserve key whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ and `MOCK_PUB` environment variables.
 ```sh
 $ heroku config:add \
     GIT_SSH="/app/git_ssh.sh" \
-    MOCK_KEY="-----BEGIN RSA PRIVATE KEY-----\nget\n\your\own\n-----END RSA PRIVATE KEY-----" \
-    MOCK_PUB="ssh-rsa publickey"
+    MOCK_KEY="`cat ~/.ssh/id_rsa`" \
+    MOCK_PUB="`cat ~/.ssh/id_rsa.pub`"
 ```
 
 ### Automatic Rebuild

--- a/git_ssh.sh
+++ b/git_ssh.sh
@@ -1,4 +1,4 @@
-echo $MOCK_KEY > /tmp/ms_key
-echo $MOCK_PUB > /tmp/ms_key.pub
+echo "$MOCK_KEY" > /tmp/ms_key
+echo "$MOCK_PUB" > /tmp/ms_key.pub
 
 exec ssh -i "/tmp/ms_key" -o "StrictHostKeyChecking no" "$@"


### PR DESCRIPTION
This avoids having to manually insert or escape newline characters in the private key.
