### PR TITLE
Match native iphone/ipad index.html urls also

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,12 @@ function resourceRewrite(req, res, next) {
   var match = /^\/r\/phoenix(-v[\d]?)?(.*)/.exec(req.url);
   if (match) {
     req.url = match[2];
+  } else {
+    // load native iphone/ipad index.html locally, match '/r/checkout/iphone//index.html'
+    match = /^\/r\/checkout\/(iphone|ipad)\/\/(index\.html)$/.exec(req.url);
+    if (match) {
+      req.url = '/' + match[1] + '/' + match[2]; // '/iphone/index.html'
+    }
   }
   next();
 }
@@ -33,6 +39,7 @@ function configure(app, secure) {
     app.use(mocks.middleware);
     app.use(staticShim);
     app.use(app.router);
+    app.use(express.static(config.appDir + '/public'));
     app.use(express.errorHandler({ dumpExceptions: true, showStack: true }));
   });
 
@@ -48,6 +55,11 @@ function configure(app, secure) {
       console.log('client:', data);
       res.send(200);
     });
+  });
+
+  app.get('/images/*', function(req, res){
+    var file = req.params[0];
+    fs.createReadStream(config.appDir + '/public/images/' + file).pipe(res);
   });
 
   app.all(/\/.*/, proxy.proxy(secure));


### PR DESCRIPTION
This came about from trying to debug the native iphone application. The native application was trying to load '/r/checkout/iphone//index.html' which resulted in a non-match and hence would pull from proxy to production's version. This fix matches that url and then loads the local development box's iphone/index.html file correctly. That way any changes made in native_checkout.js for example can be tested.
