### PR TITLE
add a --forever arg to daemonize server

### DIFF
--- a/bin/mock-server
+++ b/bin/mock-server
@@ -1,11 +1,18 @@
 #!/usr/bin/env node
 var argv = require('optimist').argv;
+var forever = require('../lib/forever')
 
 if (argv._.length !== 1) {
   console.error('Usage: mock-server appDir [--proxy-server=proxyServer] [--port=port] [--secure-port=securePort] [--live-reload] [--force-cors]');
   process.exit(1);
   return;
 }
+
+if (argv['forever']) {
+  forever();
+  return
+}
+
 
 var config = require('../lib/config');
 config.isHeroku = argv._[0] === 'heroku';

--- a/bin/mock-server
+++ b/bin/mock-server
@@ -14,6 +14,7 @@ config.proxyServer = argv['proxy-server'] || process.env.DEFAULT_PROXY;
 config.port = parseInt(argv.port || process.env.PORT || 8080);
 config.forwardPort = parseInt(argv.port || (config.isHeroku ? 80 : config.port));
 config.securePort = parseInt(argv['secure-port'] || (config.isHeroku ? 443 : 8081));
+config.forever = argv['forever'];
 config.liveReload = argv['live-reload'];
 config.forceCors = argv['force-cors'];
 

--- a/lib/forever.js
+++ b/lib/forever.js
@@ -1,0 +1,16 @@
+var forever = require('forever-monitor'),
+    path = require('path'),
+    config = require('./config');
+
+module.exports = function(app, secureApp) {
+  var args = process.argv;
+  var child
+
+  args.splice(args.indexOf('--forever',1))
+
+  console.log("\n\n\n\n\n" + args + "\n\n\n\n")
+
+  child = forever.start(args, {
+      max : 5
+    });
+};

--- a/lib/forever.js
+++ b/lib/forever.js
@@ -8,8 +8,6 @@ module.exports = function(app, secureApp) {
 
   args.splice(args.indexOf('--forever',1))
 
-  console.log("\n\n\n\n\n" + args + "\n\n\n\n")
-
   child = forever.start(args, {
       max : 5
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,6 @@ var admin = require('./admin'),
     path = require('path'),
     proxy = require('./proxy'),
     staticShim = require('./static-shim'),
-    forever = require('./forever'),
     liveReload = require('./live-reload');
 
 mocks.init();
@@ -52,11 +51,6 @@ function configure(app, secure) {
   });
 
   app.all(/\/.*/, proxy.proxy(secure));
-}
-
-if (config.forever) {
-  forever();
-  return
 }
 
 // Repo setup

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ var admin = require('./admin'),
     path = require('path'),
     proxy = require('./proxy'),
     staticShim = require('./static-shim'),
+    forever = require('./forever'),
     liveReload = require('./live-reload');
 
 mocks.init();
@@ -51,6 +52,11 @@ function configure(app, secure) {
   });
 
   app.all(/\/.*/, proxy.proxy(secure));
+}
+
+if (config.forever) {
+  forever();
+  return
 }
 
 // Repo setup

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "pubnub": "~3.4",
     "underscore": "~1.4",
     "socket.io": "~0.9",
+    "forever-monitor": "~1.2",
     "watch": "~0.7"
   },
   "bin": {


### PR DESCRIPTION
this may be too much of a hack, but it was the simpliest update possible, I think.
If the --forever flag is found, it stops short, removes that argument, and then runs the process with the same args as a daemon using forever-monitor
