### PR TITLE
ensure only isHeroku servers do ssl rewriting

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -71,7 +71,7 @@ var app = express.createServer();
 configure(app, false);
 app.listen(config.port);
 
-if (!config.isStandalone) {
+if (!config.isHeroku) {
   console.log('Starting mock-server on secure port', config.securePort);
   try {
     var hostExists = fs.statSync(config.appDir + '/host.key').isFile();


### PR DESCRIPTION
This was changed with the standalone changeover, but it seems to have been done in error. Heroku requires the ssl redirection logic, but it is useless outside of their ecosystem. Its therefore not applicable to isStandalone
