### PR TITLE
colorize logs to prevent ansi escape codes from displaying

### DIFF
--- a/lib/admin.js
+++ b/lib/admin.js
@@ -1,4 +1,6 @@
 var async = require('async'),
+    Convert = require('ansi-to-html'),
+    convert = new Convert(),
     campfire = require('./campfire'),
     config = require('./config'),
     express = require('express'),
@@ -44,7 +46,8 @@ module.exports = function(app, repo) {
         branches: branches || [],
         currentBranch: currentBranch,
         configText: JSON.stringify(config.localConfig || {}, undefined, 2),
-        log: log.logs, error: log.errors
+        log: convert.toHtml(log.logs),
+        error: log.errors
       });
     });
   });

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "underscore": "~1.4",
     "socket.io": "~0.9",
     "forever-monitor": "~1.2",
-    "watch": "~0.7"
+    "watch": "~0.7",
+    "ansi-to-html": "~0.1"
   },
   "bin": {
     "mock-server": "bin/mock-server"

--- a/views/index.jade
+++ b/views/index.jade
@@ -65,5 +65,5 @@ div
     input(type="submit", value="Update Config")
 
   h2 Log
-  pre #{log}
+  pre!=log
   pre(style="color: red") #{error}


### PR DESCRIPTION
Currently, it shows something like

```
mkdir: [90mmmaking directory [30m build
```

now it will convert those to

``` html
mkdir: <span style="color:#555">making directory</span> build
```
